### PR TITLE
[STEP 1] Wody, Kane, Ryan

### DIFF
--- a/MockDataFiles/doing.json
+++ b/MockDataFiles/doing.json
@@ -1,0 +1,58 @@
+[
+    {
+      "id": "9FAA7BA7-B7AC-4C5F-80E3-897FBDB38114",
+      "title": "삐삐",
+      "content": "Hi there 인사해 호들갑 없이 시작해요 서론 없이 스킨십은 사양할게요 back off back off 이대로 좋아요 balance balance It's me 나예요 다를 거 없이 요즘엔 뭔가요 내 가십 탐색하는 불빛 scanner scanner 오늘은 몇 점인가요? jealous jealous 쟤는 대체 왜 저런 옷을 좋아한담? 기분을 알 수 없는 저 표정은 뭐람? ",
+      "deadlineDate": "2020-10-08T06:43:10.464Z",
+      "classification": "doing",
+      "isDeleted": false
+    },
+    {
+      "id": "44DB5EDD-2210-4A52-96A1-48D65E668965",
+      "title": "금요일에 만나요",
+      "content": "월요일엔 아마 바쁘지 않을까 화요일도 성급해 보이지 안 그래 수요일은 뭔가 어정쩡한 느낌 목요일은 그냥 내가 왠지 싫어 우~ 이번주 금요일 우~ 금요일에 시간 어때요 주말까지 기다리긴 힘들어 시간아 달려라 시계를 더 보채고 싶지만 (mind control) 일분 일초가 달콤해 이 남자 도대체 뭐야 사랑에 빠지지 않곤 못 배기겠어 온 종일 내 맘은 저기 시계바늘 위에 올라타",
+      "deadlineDate": "2021-11-11T06:43:10.464Z",
+      "classification": "doing",
+      "isDeleted": false
+    },
+    {
+      "id": "A07A5EE7-BBFC-4619-AFD3-04A57DB270A3",
+      "title": "하루 끝",
+      "content": "Monday Better day 처음처럼 설레이는 그런 날 Sunday Better day 종일 너만 생각하는 그런 날 욕심이 나 우리 사이 요만큼만 더 가까이 딱 한 발짝 그만큼 더 가까이 혼잣말이 속삭임이 너도 궁금할 순 있잖아 네가 좋아서 그래 나 차가운 척 표정 짓고 있지만 내 마음은 그게 아닌데 거짓말인데 바보 같은 네가 난 답답해 너무 좋아서 그래 나 시무룩한 얼굴하고 있지만",
+      "deadlineDate": "2020-09-18T06:43:10.464Z",
+      "classification": "doing",
+      "isDeleted": false
+    },
+    {
+      "id": "AEB3CF88-EEE1-421F-8751-7C350BDCFCEC",
+      "title": "무릎",
+      "content": "I got pushed 떠밀려 왔어 오래도 찾아 헤맨 꿈의 문 앞에 내 안에 그 작은 노래가 작은 노래가 날 여기 데려왔어 외로워도 기댈 곳 없이 괴로워도 멈춤 없이 그저 참고 견딘 시간의 의미를 이제야 나 널 만난 후에야 손잡은 후에야 그 이유를 깨달아 Yeah I’m scared 두렵긴 하지만 힘차게 뛰어가 let's just try It’s our chance 수없이 새겨진 지난 발자국이 알아",
+      "deadlineDate": "2021-07-29T06:43:10.464Z",
+      "classification": "doing",
+      "isDeleted": false
+    },
+    {
+      "id": "31B3C229-EFCD-484A-87EE-9922AFA2FB61",
+      "title": "비밀의 화원",
+      "content": "바람을 타고 날아오르는 새들은 걱정 없이 아름다운 태양 속으로 음표가 되어 나네 향기 나는 연필로 쓴 일기처럼 숨겨두었던 마음 기댈 수 있는 어깨가 있어 비가 와도 젖지 않아",
+      "deadlineDate": "2022-01-01T06:43:10.464Z",
+      "classification": "doing",
+      "isDeleted": false
+    },
+    {
+      "id": "6EB45307-A3D1-4DB0-A509-44DBA3A3CDF2",
+      "title": "좋은 날",
+      "content": "어쩜 이렇게 하늘은 더 파란 건지 오늘따라 왜 바람은 또 완벽한지",
+      "deadlineDate": "2022-01-15T06:43:10.464Z",
+      "classification": "doing",
+      "isDeleted": false
+    },
+    {
+      "id": "3FB50F35-D70F-41E5-A6D2-5301DFFCC115",
+      "title": "아 지금",
+      "content": "이건 비밀이야 아무에게도 고백하지 않았던 이야기를 들려주면 큰 눈으로 너는 묻지 How wow wow, Whatever 나 실은 말이야 저기 아득한 미래로부터 날아왔어 쏟아질 듯이 빼곡한 별들 사이를 지나 Fly fly fly 있지, 그곳도 사실 바보들 투성이야 아니, 매우 반짝이는 건 오히려 Now now now 이 하루, 이 지금, 우리, 눈부셔 아름다워 이 불꽃놀이는 끝나지 않을 거야",
+      "deadlineDate": "2022-08-14T06:43:10.464Z",
+      "classification": "doing",
+      "isDeleted": false
+    }
+]

--- a/MockDataFiles/done.json
+++ b/MockDataFiles/done.json
@@ -1,0 +1,74 @@
+[
+    {
+      "id": "66249EAC-0984-42CF-BF7C-4A0BEC343B60",
+      "title": "너랑 나",
+      "content": "시곌 보며 속삭이는 비밀들",
+      "deadlineDate": "2021-01-23T06:43:10.464Z",
+      "classification": "done",
+      "isDeleted": false
+    },
+    {
+      "id": "69A88085-74F3-4B2F-923A-DA721DC3D661",
+      "title": "마음",
+      "content": "툭 웃음이 터지면 그건 너 쿵 내려앉으면은 그건 너 축 머금고 있다면 그건 너 둥 울림이 생긴다면 그건 너",
+      "deadlineDate": "2020-12-12T06:43:10.464Z",
+      "classification": "done",
+      "isDeleted": false
+    },
+    {
+      "id": "2909995C-8DFA-41FF-A44B-C4FA67EBF78D",
+      "title": "너의 의미",
+      "content": "너의 그 한 마디 말도 그 웃음도 나에겐 커다란 의미 너의 그 작은 눈빛도 쓸쓸한 뒷모습도 나에겐 힘겨운 약속 너의 모든 것은 내게로 와 풀리지 않는 수수께끼가 되네 슬픔은 간이역의 코스모스로 피고 스쳐 불어온 넌 향긋한 바람",
+      "deadlineDate": "2020-12-29T06:43:10.464Z",
+      "classification": "done",
+      "isDeleted": false
+    },
+    {
+      "id": "972663D1-79A1-4B1A-8D0E-85CB23B99D2C",
+      "title": "가을 아침",
+      "content": "이른 아침 작은 새들 노랫소리 들려오면 언제나 그랬듯 아쉽게 잠을 깬다 창문 하나 햇살 가득 눈부시게 비쳐오고 서늘한 냉기에 재채기할까 말까 (음) 눈 비비며 빼꼼히 창밖을 내다보니 삼삼오오 아이들은 재잘대며 학교 가고 산책 갔다 오시는 아버지의 양손에는 효과를 알 수 없는 약수가 하나 가득 (음) 딸각딸각 아침 짓는 어머니의 분주함과 엉금엉금 냉수 찾는 그 아들의 게으름이",
+      "deadlineDate": "2021-02-16T06:43:10.464Z",
+      "classification": "done",
+      "isDeleted": false
+    },
+    {
+      "id": "16D5C7D8-78FA-4D33-8139-5587CF04695F",
+      "title": "시간의 바깥",
+      "content": "서로를 닮아 기울어진 삶 소원을 담아 차오르는 달 하려다 만 괄호 속의 말 이제야 음 음 음 어디도 닿지 않는 나의 닻 넌 영원히 도착할 수 없는 섬 같아 헤매던 날 이제야 음 음 음 기록하지 않아도 내가 널 전부",
+      "deadlineDate": "2021-05-15T06:43:10.464Z",
+      "classification": "done",
+      "isDeleted": false
+    },
+    {
+      "id": "1B9CD487-DF0C-4114-AF4B-63ED6D83E300",
+      "title": "기를 쓰고 사랑해야 하는 건 아냐 하루 정도는 행복하지 않아도 괜찮아 그럼에도",
+      "content": "역시 완벽하군 나의 여인 um 여전히 무수한 빈칸들이 있지 끝없이 헤맬 듯해 풀리지 않는 얄미운 숙제들 사이로 마치 하루하루가 잘 짜여진 장난 같아 달릴수록 내게서 달아나 Just life, we’re still good without luck 길을 잃어도 계속 또각또각 또 가볍게 걸어",
+      "deadlineDate": "2021-04-29T06:43:10.464Z",
+      "classification": "done",
+      "isDeleted": false
+    },
+    {
+      "id": "098F80AA-9978-4BE8-99D8-E6332FB8595F",
+      "title": "늦게 다니지좀 마 술은 멀리좀 해봐 열살짜리 애처럼 말을 안듣니",
+      "content": "정말 웃음만 나와 누가 누굴보고 아이라 하는지 정말 웃음만 나와 싫은 얘기 하게 되는 내 맘을 몰라 좋은 얘기만 나누고 싶은 내맘을 몰라 그만할까 그만하자 하나부터 열까지 다 널 위한 소리 내 말 듣지 않는 너에게는 뻔한 잔소리 그만하자 그만하자 사랑하기만해도 시간 없는데 머리 아닌 가슴으로 하는 이야기",
+      "deadlineDate": "2021-03-12T06:43:10.464Z",
+      "classification": "done",
+      "isDeleted": false
+    },
+    {
+      "id": "4C5F117E-0092-4B4B-AE80-BBC61937912D",
+      "title": "미리 메리 크리스마스",
+      "content": "하얀 눈이 내려올 때면 온 세상이 물들을 때면 눈꽃이 피어나 또 빛이 나 눈이 부신 너처럼 Narr) Yeah girl you should know that That my heartbeats like Huh Huh Huh Huh From the bottom of my heart I thank god I found you Rap) 쿵쿵 가슴이 왜 이렇게 가쁘니 yeah 꾹꾹 참아도 자꾸 네 생각이 나잖아",
+      "deadlineDate": "2021-05-13T06:43:10.464Z",
+      "classification": "done",
+      "isDeleted": false
+    },
+    {
+      "id": "2C67CEC9-AE4A-438E-86DC-B409446DA0D2",
+      "title": "스물셋",
+      "content": "I'm twenty three 난 수수께끼 (Question) 뭐게요 맞혀봐요 I'm twenty three 틀리지 말기 Because 난 몹시 예민해요 맞혀봐 한 떨기 스물셋 좀 아가씨 태가 나네 다 큰 척해도 적당히 믿어줘요 얄미운 스물셋 아직 한참 멀었다 얘 덜 자란 척해도 대충 속아줘요 난, 그래 확실히 지금이 좋아요 아냐, 아냐 사실은 때려 치고 싶어요 아 알겠어요",
+      "deadlineDate": "2021-06-29T06:43:10.464Z",
+      "classification": "done",
+      "isDeleted": false
+    }
+]

--- a/MockDataFiles/todo.json
+++ b/MockDataFiles/todo.json
@@ -1,0 +1,66 @@
+[
+    {
+      "id": "ODJ2D375-85IF-ABD4-9B03-B6DF3F5B9891",
+      "title": "잘생긴 케인",
+      "content": "훗.. 불쌍하게도 못 생겼군.",
+      "deadlineDate": "2020-05-29T06:43:10.464Z",
+      "classification": "todo",
+      "isDeleted": false
+    },
+    {
+      "id": "E1C341F6-6A26-406E-960E-2A4A2E6A4BAA",
+      "title": "나리는 꽃가루에 눈이 따끔해 (아야)",
+      "content": "눈물이 고여도 꾹 참을래 내 마음 한켠 비밀스런 오르골에 넣어두고서 영원히 되감을 순간이니까",
+      "deadlineDate": "2021-02-14T06:43:10.464Z",
+      "classification": "todo",
+      "isDeleted": false
+    },
+    {
+      "id": "6354CD2A-BEF1-4554-B9B9-5D16F9FFF0C4",
+      "title": "오 라일락 꽃이 지는 날 goodbye",
+      "content": "이런 결말이 어울려 안녕 꽃잎 같은 안녕 하이얀 우리 봄날의 climax 아 얼마나 기쁜 일이야",
+      "deadlineDate": "2020-03-31T06:43:10.464Z",
+      "classification": "todo",
+      "isDeleted": false
+    },
+    {
+      "id": "FA296DA6-90F5-419C-8630-CA6A161FADEB",
+      "title": "I'm such a good surfer",
+      "content": "어어어 푸푸푸 또 허허허 우우우적 거거거 리더던 시 저저절 나라면 워어언 이 사람아 언제적 얘길 꺼내나 보란듯이 헤엄치기 처첨버벙 저저적 셔셔셔 또 저저적 셔셔셔 거거겁 없이 몸을 더더던 져져져",
+      "deadlineDate": "2021-08-26T06:43:10.464Z",
+      "classification": "todo",
+      "isDeleted": false
+    },
+    {
+      "id": "B844BEEA-1C3A-4A3A-8F8A-37F94DF6EE5A",
+      "title": "강자에게 더 세게 I love gamble",
+      "content": "과감할수록 신세계 on my table I'm sorry 세상이 원래 불공평해 So 더럽게 재미있지 Now I move I move I move I move I move Go ahead I don't look no look no look no look no look What's in my hand I said go Baby 알잖아 내가 한 번 미치면 어디까지",
+      "deadlineDate": "2021-11-30T06:43:10.464Z",
+      "classification": "todo",
+      "isDeleted": false
+    },
+    {
+      "id": "062CF1A4-F09F-4AF5-9335-CB55489D8814",
+      "title": "내 손을 잡아",
+      "content": "느낌이 오잖아 떨리고 있잖아 언제까지 눈치만 볼 거니 네 맘을 말해봐 딴청 피우지 말란 말이야 네 맘 가는 그대로 지금 내 손을 잡아 어서 내 손을 잡아 우연히 고개를 돌릴 때 마다 눈이 마주치는 건 몇일밤 내내 꿈속에 나타나 밤새 나를 괴롭히는 건 그 많은 빈자리 중에서 하필 내 옆자릴 고르는 건 나도 모르게 어느새 실없는 웃음 흘리고 있다는 건 그럼 말 다했지 뭐, 우리 얘기 좀 할까",
+      "deadlineDate": "2020-06-29T06:43:10.464Z",
+      "classification": "todo",
+      "isDeleted": false
+    },
+    {
+      "id": "2D794E86-F912-45BA-B34C-F76F2C8369C4",
+      "title": "에잇",
+      "content": "So are you happy now Finally happy now are you 뭐 그대로야 난 다 잃어버린 것 같아 모든 게 맘대로 왔다가 인사도 없이 떠나 이대로는 무엇도 사랑하고 싶지 않아 다 해질 대로 해져버린 기억 속을 여행해 우리는 오렌지 태양 아래 그림자 없이 함께 춤을 춰 정해진 이별 따위는 없어 아름다웠던 그 기억에서 만나 Forever young 우우우 우우우우 우우우",
+      "deadlineDate": "2021-12-13T06:43:10.464Z",
+      "classification": "todo",
+      "isDeleted": false
+    },
+    {
+      "id": "5D728F1F-5791-45AE-9CC1-799C334999A3",
+      "title": "Love Poem",
+      "content": "누구를 위해 누군가 기도하고 있나 봐 숨죽여 쓴 사랑시가 낮게 들리는 듯해 너에게로 선명히 날아가 늦지 않게 자리에 닿기를 I’ll be there 홀로 걷는 너의 뒤에 Singing till the end 그치지 않을 이 노래 아주 잠시만 귀 기울여 봐 유난히 긴 밤을 걷는 널 위해 부를게 또 한 번 너의 세상에 별이 지고 있나 봐 숨죽여 삼킨 눈물이 여기 흐르는 듯해 할 말을 잃어",
+      "deadlineDate": "2022-12-30T06:43:10.464Z",
+      "classification": "todo",
+      "isDeleted": false
+    }
+]

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 - 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
 
-
+### [API 문서](https://projectmanagementapp.gitbook.io/projectmanagemen/)


### PR DESCRIPTION
@myssun0325 

메이슨, 안녕하세요!
이번 프로젝트 잘 부탁드립니다~!

이번 STEP에서는 클라이언트측과 두 번의 조율 끝에 API 문서와 mock 데이터 초안을 발행하여 공유하였어요.

# 요구사항에 대한 구현
### REST를 이해하고 API를 설계합니다 
- 클라이언트와 서버가 분리되어 있습니다.
- HTTP 메서드를 통해 요청이 관리됩니다.
- URL 네이밍을 통해 자체 표현 구조를 만족시키고 있습니다. 
- 이로써 일반적인 의미의 RESTful API 조건을 만족시키고 있지만 향후 REST의 조건 중 하나인 uniform interface를 만족시키기 위해 [이 영상](https://www.youtube.com/watch?v=RP_f5dMoHFc&t=1s)을 참고하여 아래 사항들을 response에 추가하려 합니다.
    - 헤더에 Profile을 통해 API 문서 링크 추가 (self-descriptive)
      - `Link: <https://app.gitbook.com/@projectmanagementapp/s/projectmanagemen>; rel="profile"`
    - 데이터에 자신을 나타낼 수 있는 링크 추가 (HATEOAS)
### API를 문서화하여 클라이언트 측에 제공합니다
- Gitbook을 통해 [API 문서](https://app.gitbook.com/@projectmanagementapp/s/projectmanagemen/)를 작성하였습니다.
### 응답에 대한 mock 데이터를 클라이언트 측에 제공합니다
  - API 문서에서 파악하실 수 있으시듯이 `https://baseurl/projectItems` 엔드포인트에서 클라이언트측에서 필요로하는 전체 `projectItem` 데이터들을 제공하되, `todo / doing / done` 분류를 쿼리를 통해 서버에 요청하면 해당 상태로 분류된 `projectItem`들만 반환하도록 계획하고 있습니다.
  - 따라서 클라이언트가 아래와 같이 서버에 세 번의 요청을 하였다고 가정하고 `todo.json`, `doing.json`, `done.json` 세 가지 mock 데이터를 제공하였습니다 (소스코드에 첨부하였습니다).
    - https://projectmanagerserver.herokuapp.com/projectItems?classification="todo"
    - https://projectmanagerserver.herokuapp.com/projectItems?classification="doing"
    - https://projectmanagerserver.herokuapp.com/projectItems?classification="done"

# 조언을 얻고 싶은 부분
### 1. 데이터 관리 방식 관련
GET과 POST HTTP 메서드를 통한 요청으로는 통상적인 의미와 같이 조회와 새로운 데이터 등록 요청이 가능합니다. 하지만 API 문서에도 드러나 있듯이 서버에서는 앱 사용자가 데이터 삭제 요청을하면 클라이언트가 PATCH 메서드를 통해 `isDeleted` 프로퍼티를 `true`로 변경하도록 서버에 요청하여 삭제 처리가 진행됩니다. 이렇게 처리한 이유는 향후 앱 사용자의 `undo` 요청에 따라 삭제된 데이터를 복구해야할 필요가 있을 수 있다고 판단했기 때문이지만, 클라이언트에서 데이터 삭제를 위해 DELETE가 아닌 PATCH를 통해 삭제 요청하여야 한다는 점이 자연스럽지 않다고 느낄 수 있다고 생각했습니다. 이러한 점에서 가능하다면 클라이언트는 통상적인 방법처럼 DELETE 메서드를 통해 데이터 삭제를 서버에 요청하고, `isDeleted`와 같은 정보들은 서버에서만 관리하도록 처리하는 것이 자연스러울까요? 메이슨의 의견이 궁금합니다.

### 2. DB 데이터의 구조에 따라 URL을 적절하게 네이밍하였는지 궁금합니다.
제공되는 페이지는 메서드별로 아래 두 가지입니다.
- GET: https://projectmanagerserver.herokuapp.com/projectItems
- POST, PATCH: https://projectmanagerserver.herokuapp.com/projectItem

GET과 POST는 URL 이름을 통해 자연스럽게 `projectItems를 조회하는구나`, `새로운 projectItem을 등록하는구나`라고 판단할 수 있다고 생각합니다. 하지만 PATCH는 데이터의 수정과 삭제를 함께 수행하고 있기에 요청만으로는 내용을 파악하기 어려울 수 있다고 생각합니다. 예를 들어 `PATCH https://baseurl/projectItem` 만으로는 데이터를 수정하는 것인지 삭제하는 것인지 판단하기 어려울 것입니다. 이런 경우 RESTful API의 원칙인 URL에 동사를 넣지 않는다라는 원칙을 어기게 되더라도 요청을 명확하게 파악할 수 있도록 `PATCH https://baseurl/projectItem/delete`와 같이 정확한 네이밍을 하는 편이 나을까요? 메이슨의 의견은 어떠신가요? 

감사합니다!