### PR TITLE
[Step 3] Steven, 덕복

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ bh_unicode_properties.cache
 # Sublime-github package stores a github token in this file
 # https://packagecontrol.io/packages/sublime-github
 GitHub.sublime-settings
+
+# 로컬 PostgreSQL 설정
+Config/secrets

--- a/Sources/App/Controllers/TaskController.swift
+++ b/Sources/App/Controllers/TaskController.swift
@@ -18,41 +18,58 @@ struct TaskController: RouteCollection {
             tasks.delete(use: delete)
         }
     }
-    
+
     func showAll(req: Request) throws -> EventLoopFuture<[Task]> {
         return Task.query(on: req.db).all()
     }
-    
+
     func create(req: Request) throws -> EventLoopFuture<Task> {
         let task = try req.content.decode(Task.self)
         return task.create(on: req.db).map { task }
     }
-    
+
     func update(req: Request) throws -> EventLoopFuture<Task> {
+        guard let id = req.parameters.get("id", as: Int.self) else { throw Abort(.notFound) }
         let patchTask = try req.content.decode(PatchTask.self)
-        return Task.find(req.parameters.get("id"), on: req.db)
+
+        return Task.find(id, on: req.db)
             .unwrap(or: Abort(.notFound))
             .flatMap { task in
-                if let title = patchTask.title {
+                var isChanged: Bool = false
+
+                if let title = patchTask.title,
+                   task.title != title {
                     task.title = title
+                    isChanged = true
                 }
-                
-                if let deadline = patchTask.deadline {
+
+                if let deadline = patchTask.deadline,
+                   task.deadline != deadline {
                     task.deadline = deadline
+                    isChanged = true
                 }
-                
-                if let state = patchTask.state {
+
+                if let state = patchTask.state,
+                   task.state != state {
                     task.state = state
+                    isChanged = true
                 }
-                
-                if let contents = patchTask.contents {
+
+                if let contents = patchTask.contents,
+                   task.contents != contents {
                     task.contents = contents
+                    isChanged = true
                 }
-                
+
+                guard isChanged else {
+                    return Task.find(id, on: req.db)
+                        .unwrap(or: Abort(.notFound))
+                }
+
                 return task.update(on: req.db).transform(to: task)
             }
     }
-    
+
     func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
         return Task.find(req.parameters.get("id"), on: req.db)
                     .unwrap(or: Abort(.notFound))

--- a/Sources/App/Controllers/TaskController.swift
+++ b/Sources/App/Controllers/TaskController.swift
@@ -40,8 +40,8 @@ struct TaskController: RouteCollection {
         try PatchTask.validate(content: req)
         let patchTask = try req.content.decode(PatchTask.self)
         guard !patchTask.isEmpty else { throw TaskControllerError.patchTaskIsEmpty }
-
-        return Task.find(id, on: req.db)
+        
+        let eventLoopFutureTask: EventLoopFuture<Task> = Task.find(id, on: req.db)
             .unwrap(or: TaskControllerError.idNotFound)
             .flatMap { task in
                 var isChanged: Bool = false
@@ -77,6 +77,8 @@ struct TaskController: RouteCollection {
 
                 return task.update(on: req.db).transform(to: task)
             }
+
+        return eventLoopFutureTask
     }
 
     func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {

--- a/Sources/App/Controllers/TaskController.swift
+++ b/Sources/App/Controllers/TaskController.swift
@@ -24,12 +24,14 @@ struct TaskController: RouteCollection {
     }
 
     func create(req: Request) throws -> EventLoopFuture<Task> {
+        guard req.headers.contentType == .json else { throw Abort(.unsupportedMediaType) }
         let task = try req.content.decode(Task.self)
         return task.create(on: req.db).map { task }
     }
 
     func update(req: Request) throws -> EventLoopFuture<Task> {
         guard let id = req.parameters.get("id", as: Int.self) else { throw Abort(.notFound) }
+        guard req.headers.contentType == .json else { throw Abort(.unsupportedMediaType) }
         let patchTask = try req.content.decode(PatchTask.self)
 
         return Task.find(id, on: req.db)

--- a/Sources/App/Controllers/TaskController.swift
+++ b/Sources/App/Controllers/TaskController.swift
@@ -13,9 +13,9 @@ struct TaskController: RouteCollection {
         let tasks = routes.grouped("tasks")
         tasks.get(use: showAll)
         tasks.post(use: create)
-        tasks.group(":id") { tasks in
-            tasks.patch(use: update)
-            tasks.delete(use: delete)
+        tasks.group(":id") { task in
+            task.patch(use: update)
+            task.delete(use: delete)
         }
     }
 

--- a/Sources/App/Controllers/TaskController.swift
+++ b/Sources/App/Controllers/TaskController.swift
@@ -1,0 +1,21 @@
+//
+//  TaskController.swift
+//  
+//
+//  Created by steven on 2021/07/05.
+//
+
+import Vapor
+import Fluent
+
+struct TaskController: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        let tasks = routes.grouped("tasks")
+        tasks.get(use: showAll)
+    }
+    
+    func showAll(req: Request) throws -> EventLoopFuture<[Task]> {
+        return Task.query(on: req.db).all()
+    }
+    
+}

--- a/Sources/App/Controllers/TaskController.swift
+++ b/Sources/App/Controllers/TaskController.swift
@@ -15,6 +15,7 @@ struct TaskController: RouteCollection {
         tasks.post(use: create)
         tasks.group(":id") { tasks in
             tasks.patch(use: update)
+            tasks.delete(use: delete)
         }
     }
     
@@ -50,5 +51,12 @@ struct TaskController: RouteCollection {
                 
                 return task.update(on: req.db).transform(to: task)
             }
+    }
+    
+    func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
+        return Task.find(req.parameters.get("id"), on: req.db)
+                    .unwrap(or: Abort(.notFound))
+                    .flatMap { $0.delete(on: req.db) }
+                    .transform(to: .noContent)
     }
 }

--- a/Sources/App/Controllers/TaskController.swift
+++ b/Sources/App/Controllers/TaskController.swift
@@ -27,7 +27,11 @@ struct TaskController: RouteCollection {
         guard req.headers.contentType == .json else { throw TaskControllerError.contentTypeIsNotJSON }
         try Task.validate(content: req)
         let task = try req.content.decode(Task.self)
-        return task.create(on: req.db).map { task }.encodeResponse(status: .created, for: req)
+        let eventLoopFutureTask = task.create(on: req.db).map { () -> Task in
+            return task
+        }
+
+        return eventLoopFutureTask.encodeResponse(status: .created, for: req)
     }
 
     func update(req: Request) throws -> EventLoopFuture<Task> {

--- a/Sources/App/Controllers/TaskController.swift
+++ b/Sources/App/Controllers/TaskController.swift
@@ -12,10 +12,15 @@ struct TaskController: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
         let tasks = routes.grouped("tasks")
         tasks.get(use: showAll)
+        tasks.post(use: create)
     }
     
     func showAll(req: Request) throws -> EventLoopFuture<[Task]> {
         return Task.query(on: req.db).all()
     }
     
+    func create(req: Request) throws -> EventLoopFuture<Task> {
+        let task = try req.content.decode(Task.self)
+        return task.create(on: req.db).map { task }
+    }
 }

--- a/Sources/App/Controllers/TaskController.swift
+++ b/Sources/App/Controllers/TaskController.swift
@@ -83,10 +83,10 @@ struct TaskController: RouteCollection {
 
     func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
         guard let id = req.parameters.get("id", as: Int.self) else { throw TaskControllerError.invalidID }
-
-        return Task.find(id, on: req.db)
-            .unwrap(or: TaskControllerError.idNotFound)
-            .flatMap { $0.delete(on: req.db) }
-            .transform(to: .noContent)
+        let eventLoopFutureHttpStatus = Task.find(id, on: req.db)
+                                        .unwrap(or: TaskControllerError.idNotFound)
+                                        .flatMap { $0.delete(on: req.db) }
+                                        .transform(to: .noContent)
+        return eventLoopFutureHttpStatus
     }
 }

--- a/Sources/App/Controllers/TaskController.swift
+++ b/Sources/App/Controllers/TaskController.swift
@@ -33,6 +33,7 @@ struct TaskController: RouteCollection {
         guard let id = req.parameters.get("id", as: Int.self) else { throw Abort(.notFound) }
         guard req.headers.contentType == .json else { throw Abort(.unsupportedMediaType) }
         let patchTask = try req.content.decode(PatchTask.self)
+        guard !patchTask.isEmpty else { throw Abort(.imATeapot) }
 
         return Task.find(id, on: req.db)
             .unwrap(or: Abort(.notFound))

--- a/Sources/App/Controllers/TaskController.swift
+++ b/Sources/App/Controllers/TaskController.swift
@@ -25,6 +25,7 @@ struct TaskController: RouteCollection {
 
     func create(req: Request) throws -> EventLoopFuture<Task> {
         guard req.headers.contentType == .json else { throw Abort(.unsupportedMediaType) }
+        try Task.validate(content: req)
         let task = try req.content.decode(Task.self)
         return task.create(on: req.db).map { task }
     }
@@ -32,6 +33,7 @@ struct TaskController: RouteCollection {
     func update(req: Request) throws -> EventLoopFuture<Task> {
         guard let id = req.parameters.get("id", as: Int.self) else { throw Abort(.notFound) }
         guard req.headers.contentType == .json else { throw Abort(.unsupportedMediaType) }
+        try PatchTask.validate(content: req)
         let patchTask = try req.content.decode(PatchTask.self)
         guard !patchTask.isEmpty else { throw Abort(.imATeapot) }
 

--- a/Sources/App/Controllers/TaskController.swift
+++ b/Sources/App/Controllers/TaskController.swift
@@ -23,11 +23,11 @@ struct TaskController: RouteCollection {
         return Task.query(on: req.db).all()
     }
 
-    func create(req: Request) throws -> EventLoopFuture<Task> {
+    func create(req: Request) throws -> EventLoopFuture<Response> {
         guard req.headers.contentType == .json else { throw TaskControllerError.contentTypeIsNotJSON }
         try Task.validate(content: req)
         let task = try req.content.decode(Task.self)
-        return task.create(on: req.db).map { task }
+        return task.create(on: req.db).map { task }.encodeResponse(status: .created, for: req)
     }
 
     func update(req: Request) throws -> EventLoopFuture<Task> {
@@ -79,8 +79,8 @@ struct TaskController: RouteCollection {
         guard let id = req.parameters.get("id", as: Int.self) else { throw TaskControllerError.invalidID }
 
         return Task.find(id, on: req.db)
-                    .unwrap(or: TaskControllerError.idNotFound)
-                    .flatMap { $0.delete(on: req.db) }
-                    .transform(to: .noContent)
+            .unwrap(or: TaskControllerError.idNotFound)
+            .flatMap { $0.delete(on: req.db) }
+            .transform(to: .noContent)
     }
 }

--- a/Sources/App/Controllers/TaskControllerError.swift
+++ b/Sources/App/Controllers/TaskControllerError.swift
@@ -1,0 +1,41 @@
+//
+//  TaskControllerError.swift
+//  
+//
+//  Created by duckbok on 2021/07/05.
+//
+
+import Vapor
+
+enum TaskControllerError {
+    case contentTypeIsNotJSON
+    case invalidID
+    case idNotFound
+    case patchTaskIsEmpty
+}
+
+extension TaskControllerError: AbortError {
+    var status: HTTPResponseStatus {
+        switch self {
+        case .contentTypeIsNotJSON:
+            return .unsupportedMediaType
+        case .invalidID, .idNotFound:
+            return .notFound
+        case .patchTaskIsEmpty:
+            return .noContent
+        }
+    }
+
+    var reason: String {
+        switch self {
+        case .contentTypeIsNotJSON:
+            return "Content-Type of request header must be application/json"
+        case .invalidID:
+            return "Parameter for ID must be number"
+        case .idNotFound:
+            return "ID does not exist"
+        case .patchTaskIsEmpty:
+            return ""
+        }
+    }
+}

--- a/Sources/App/Migrations/TaskMigration.swift
+++ b/Sources/App/Migrations/TaskMigration.swift
@@ -17,7 +17,7 @@ struct TaskMigration: Migration {
 
         return database.enum("state").read().flatMap { state in
             database.schema(Task.schema)
-                .id()
+                .field("id", .int, .identifier(auto: true))
                 .field("title", .string, .required)
                 .field("deadline", .date, .required)
                 .field("state", state, .required)

--- a/Sources/App/Migrations/TaskMigration.swift
+++ b/Sources/App/Migrations/TaskMigration.swift
@@ -19,7 +19,7 @@ struct TaskMigration: Migration {
             database.schema(Task.schema)
                 .field("id", .int, .identifier(auto: true))
                 .field("title", .string, .required)
-                .field("deadline", .date, .required)
+                .field("deadline", .datetime, .required)
                 .field("state", state, .required)
                 .field("contents", .string)
                 .field("last_modified_date", .datetime, .required)

--- a/Sources/App/Models/PatchTask.swift
+++ b/Sources/App/Models/PatchTask.swift
@@ -20,3 +20,12 @@ struct PatchTask: Decodable {
             && contents == nil
     }
 }
+
+extension PatchTask: Validatable {
+    static func validations(_ validations: inout Validations) {
+        validations.add("title", as: String.self, is: .count(1...50), required: false)
+        validations.add("state", as: String.self, is: .in("todo", "doing", "done"), required: false)
+        validations.add("deadline", as: Double.self, is: .range(0...253402182000), required: false)
+        validations.add("contents", as: String.self, is: .count(1...1000), required: false)
+    }
+}

--- a/Sources/App/Models/PatchTask.swift
+++ b/Sources/App/Models/PatchTask.swift
@@ -5,11 +5,18 @@
 //  Created by steven on 2021/07/05.
 //
 
-import Foundation
+import Vapor
 
 struct PatchTask: Decodable {
     let title: String?
     let deadline: Date?
     let state: State?
     let contents: String?
+
+    var isEmpty: Bool {
+        return title == nil
+            && deadline == nil
+            && state == nil
+            && contents == nil
+    }
 }

--- a/Sources/App/Models/PatchTask.swift
+++ b/Sources/App/Models/PatchTask.swift
@@ -14,10 +14,11 @@ struct PatchTask: Decodable {
     let contents: String?
 
     var isEmpty: Bool {
-        return title == nil
-            && deadline == nil
-            && state == nil
-            && contents == nil
+        let isEmpty = title == nil
+                   && deadline == nil
+                   && state == nil
+                   && contents == nil
+        return isEmpty
     }
 }
 

--- a/Sources/App/Models/PatchTask.swift
+++ b/Sources/App/Models/PatchTask.swift
@@ -1,0 +1,15 @@
+//
+//  PatchTask.swift
+//  
+//
+//  Created by steven on 2021/07/05.
+//
+
+import Foundation
+
+struct PatchTask: Decodable {
+    let title: String?
+    let deadline: Date?
+    let state: State?
+    let contents: String?
+}

--- a/Sources/App/Models/PatchTask.swift
+++ b/Sources/App/Models/PatchTask.swift
@@ -24,7 +24,7 @@ struct PatchTask: Decodable {
 extension PatchTask: Validatable {
     static func validations(_ validations: inout Validations) {
         validations.add("title", as: String.self, is: .count(1...50), required: false)
-        validations.add("state", as: String.self, is: .in("todo", "doing", "done"), required: false)
+        validations.add("state", as: String.self, is: .in(State.description), required: false)
         validations.add("deadline", as: Double.self, is: .range(0...253402182000), required: false)
         validations.add("contents", as: String.self, is: .count(1...1000), required: false)
     }

--- a/Sources/App/Models/Task.swift
+++ b/Sources/App/Models/Task.swift
@@ -49,3 +49,12 @@ final class Task: Model, Content {
 enum State: String, Codable {
     case todo, doing, done
 }
+
+extension Task: Validatable {
+    static func validations(_ validations: inout Validations) {
+        validations.add("title", as: String.self, is: .count(1...50), required: true)
+        validations.add("state", as: String.self, is: .in("todo", "doing", "done"), required: true)
+        validations.add("deadline", as: Double.self, is: .range(0...253402182000), required: true)
+        validations.add("contents", as: String.self, is: .count(1...1000), required: false)
+    }
+}

--- a/Sources/App/Models/Task.swift
+++ b/Sources/App/Models/Task.swift
@@ -46,15 +46,19 @@ final class Task: Model, Content {
     }
 }
 
-enum State: String, Codable {
+enum State: String, Codable, CaseIterable {
     case todo, doing, done
+
+    static var description: [String] {
+        return Self.allCases.map { $0.rawValue }
+    }
 }
 
 extension Task: Validatable {
     static func validations(_ validations: inout Validations) {
         validations.add("id", as: Int?.self, is: .nil, required: false)
         validations.add("title", as: String.self, is: .count(1...50), required: true)
-        validations.add("state", as: String.self, is: .in("todo", "doing", "done"), required: true)
+        validations.add("state", as: String.self, is: .in(State.description), required: true)
         validations.add("deadline", as: Double.self, is: .range(0...253402182000), required: true)
         validations.add("contents", as: String.self, is: .count(1...1000), required: false)
         validations.add("last_modified_date", as: Double?.self, is: .nil, required: false)

--- a/Sources/App/Models/Task.swift
+++ b/Sources/App/Models/Task.swift
@@ -26,7 +26,7 @@ final class Task: Model, Content {
     @OptionalField(key: "contents")
     var contents: String?
 
-    @Timestamp(key: "last_modified_date", on: .update, format: .unix)
+    @Timestamp(key: "last_modified_date", on: .update)
     var lastModifiedDate: Date?
 
     init() { }

--- a/Sources/App/Models/Task.swift
+++ b/Sources/App/Models/Task.swift
@@ -52,9 +52,11 @@ enum State: String, Codable {
 
 extension Task: Validatable {
     static func validations(_ validations: inout Validations) {
+        validations.add("id", as: Int?.self, is: .nil, required: false)
         validations.add("title", as: String.self, is: .count(1...50), required: true)
         validations.add("state", as: String.self, is: .in("todo", "doing", "done"), required: true)
         validations.add("deadline", as: Double.self, is: .range(0...253402182000), required: true)
         validations.add("contents", as: String.self, is: .count(1...1000), required: false)
+        validations.add("last_modified_date", as: Double?.self, is: .nil, required: false)
     }
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -13,6 +13,7 @@ private func configurePostgres(_ app: Application) {
     if let databaseURL = Environment.get("DATABASE_URL"),
        var postgresConfig = PostgresConfiguration(url: databaseURL) {
         postgresConfig.tlsConfiguration = .makeClientConfiguration()
+        postgresConfig.tlsConfiguration?.renegotiationSupport = .none
         app.databases.use(.postgres(configuration: postgresConfig), as: .psql)
     } else {
         guard let localPostgresData = try? String(contentsOfFile: DirectoryConfiguration.detect().workingDirectory

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -16,8 +16,7 @@ private func configurePostgres(_ app: Application) {
         postgresConfig.tlsConfiguration?.certificateVerification = .none
         app.databases.use(.postgres(configuration: postgresConfig), as: .psql)
     } else {
-        guard let localPostgresData = try? String(contentsOfFile: DirectoryConfiguration.detect().workingDirectory
-                                                    + LocalPostgres.filePath).data(using: .utf8),
+        guard let localPostgresData = try? String(contentsOfFile: LocalPostgres.filePath).data(using: .utf8),
               let localPostgres = try? JSONDecoder().decode(LocalPostgres.self, from: localPostgresData) else { return }
 
         app.databases.use(.postgres(hostname: LocalPostgres.hostname,
@@ -38,7 +37,7 @@ private func configureDateStrategy() {
 }
 
 private struct LocalPostgres: Decodable {
-    static let filePath: String = "Config/secrets/local_postgres.json"
+    static let filePath: String = DirectoryConfiguration.detect().workingDirectory + "Config/secrets/local_postgres.json"
     static let hostname: String = "localhost"
 
     let username: String

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -13,5 +13,23 @@ private func configurePostgres(_ app: Application) {
        var postgresConfig = PostgresConfiguration(url: databaseURL) {
         postgresConfig.tlsConfiguration = .makeClientConfiguration()
         app.databases.use(.postgres(configuration: postgresConfig), as: .psql)
+    } else {
+        guard let localPostgresData = try? String(contentsOfFile: DirectoryConfiguration.detect().workingDirectory
+                                                    + LocalPostgres.filePath).data(using: .utf8),
+              let localPostgres = try? JSONDecoder().decode(LocalPostgres.self, from: localPostgresData) else { return }
+
+        app.databases.use(.postgres(hostname: LocalPostgres.hostname,
+                                    username: localPostgres.username,
+                                    password: localPostgres.password,
+                                    database: localPostgres.database), as: .psql)
     }
+}
+
+private struct LocalPostgres: Decodable {
+    static let filePath: String = "Config/secrets/local_postgres.json"
+    static let hostname: String = "localhost"
+
+    let username: String
+    let password: String
+    let database: String
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -5,6 +5,7 @@ import Vapor
 public func configure(_ app: Application) throws {
     configurePostgres(app)
     app.migrations.add(TaskMigration())
+    configureDateStrategy()
     try routes(app)
 }
 
@@ -23,6 +24,16 @@ private func configurePostgres(_ app: Application) {
                                     password: localPostgres.password,
                                     database: localPostgres.database), as: .psql)
     }
+}
+
+private func configureDateStrategy() {
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    encoder.dateEncodingStrategy = .secondsSince1970
+    decoder.dateDecodingStrategy = .secondsSince1970
+
+    ContentConfiguration.global.use(encoder: encoder, for: .json)
+    ContentConfiguration.global.use(decoder: decoder, for: .json)
 }
 
 private struct LocalPostgres: Decodable {

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -13,7 +13,7 @@ private func configurePostgres(_ app: Application) {
     if let databaseURL = Environment.get("DATABASE_URL"),
        var postgresConfig = PostgresConfiguration(url: databaseURL) {
         postgresConfig.tlsConfiguration = .makeClientConfiguration()
-        postgresConfig.tlsConfiguration?.renegotiationSupport = .none
+        postgresConfig.tlsConfiguration?.certificateVerification = .none
         app.databases.use(.postgres(configuration: postgresConfig), as: .psql)
     } else {
         guard let localPostgresData = try? String(contentsOfFile: DirectoryConfiguration.detect().workingDirectory

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -1,11 +1,5 @@
 import Vapor
 
 func routes(_ app: Application) throws {
-    app.get { req in
-        return "It works!"
-    }
-
-    app.get("hello") { req -> String in
-        return "Hello, world!"
-    }
+    try app.register(collection: TaskController())
 }


### PR DESCRIPTION
@AppleCEO 안녕하세요 도미닉~ 세번째 PR 올립니다 🥳
이번 스텝에서 API 구현을 해봤습니다! 대부분 내용이 [Vapor 공식문서](https://docs.vapor.codes/4.0/)에 존재하여 이를 많이 참고하며 진행을 했어요. 아무래도 정해진 구조위에서 작업을 하여 특이사항은 거의 없는 것 같습니다!
도미닉이 보시기에 어색한 부분이 있다면 알려주시고, 배포한 서버를 바탕으로 Postman을 통해 [API 문서](https://documenter.getpostman.com/view/15740314/Tzm3nd22#24c46ffa-2cf1-471e-9ec3-8b137f8d6b54)를 작성했으니 참고해주세요!

## 고민했던 점
- Vapor에서 제공하는 `Validatable`을 통해 Model에 들어가는 데이터를 검증하는 로직을 추가하면 자동으로 Error handling을 하여 저희가 원하는 message나 status code를 줄 수가 없어보였습니다. 그래서 커스텀이 필요한 경우 따로 `TaskControllerError`를 정의하여 사용하고, `400 Bad Request`로 표현이 충분하다고 판단한 사항은 해당 프로토콜로 처리를 했습니다.
- 로컬 DB에 대한 설정은 `.gitignore`에 등록된 `Config/secrets/local_postgres.json`에 두어 heroku에서 돌아가지 않고, 이 파일이 존재한다면 연결하는 방식으로 설정했습니다.

## 조언을 얻고싶은 점
- Patch시에 모든 데이터를 `optional`로 받아오기에 기존의 정의된 `Task` 모델을 사용할 수가 없었습니다. 여기서 삽질을 하다가 공식문서에 [Data Transfer Object](https://docs.vapor.codes/4.0/fluent/model/#data-transfer-object)를 발견하고 이를 참고하여 진행하였는데요, 이렇게 일일이 비교하는 방식이 가장 최선일 지 궁금합니다.
- Patch 요청에서 아무 것도 없거나 변경되지 않을 데이터를 요청했을 시에, 전자의 경우 `204 No Content`를 응답하고 후자의 경우는 최종 수정시간을 변경하지 않고 `200 OK`와 함께 해당 `Task`를 반환해주는 방식으로 구현했습니다. 근데 이 방식이 맞는 것인지 의문이 들어 조언을 얻고 싶네요!
- `Date` 타입을 UNIX Timestamp를 위해 `Double`로 주고받고, 데이터베이스 내에서는 `DateTime`으로 저장하는 방향으로 잡았습니다. 현업에서는 어떤 방식을 선호하고 많이 사용하는 지 조언을 얻고 싶습니다! 추가로 시간의 범위도 우선 `1970/01/01`에서 `9999/12/31`로 제한을 뒀는데 이렇게 해도 괜찮을까요?