### PR TITLE
[Step3] 수킴, 헤일리, 네프

### DIFF
--- a/Sources/App/Controllers/MemoController.swift
+++ b/Sources/App/Controllers/MemoController.swift
@@ -72,11 +72,13 @@ struct MemoController: RouteCollection {
     }
     
     func create(request: Request) throws -> EventLoopFuture<Memo> {
+        try Memo.validate(content: request)
         let memo = try request.content.decode(Memo.self)
         return memo.create(on: request.db).map { memo }
     }
     
     func update(request: Request) throws -> EventLoopFuture<HTTPStatus> {
+        try Memo.validate(content: request)
         let memo = try request.content.decode(Memo.self)
         return Memo.find(request.parameters.get("memoId"), on: request.db)
             .unwrap(or: Abort(.notFound))
@@ -89,7 +91,6 @@ struct MemoController: RouteCollection {
     }
     
     func delete(request: Request) throws -> EventLoopFuture<HTTPStatus> {
-
         return Memo.find(request.parameters.get("memoId"), on: request.db)
             .unwrap(or: Abort(.notFound))
             .flatMap {

--- a/Sources/App/Controllers/MemoController.swift
+++ b/Sources/App/Controllers/MemoController.swift
@@ -67,7 +67,7 @@ extension MemoController {
         let contentType = request.headers["Content-Type"]
 
         if contentType != ["application/json"] {
-            throw Abort(.custom(code: 400, reasonPhrase: "Content-Type should be application/json"))
+            throw MemoError.contentTypeIsNotJSON
         }
 
         try Memo.validate(content: request)
@@ -83,14 +83,14 @@ extension MemoController {
         let contentType = request.headers["Content-Type"]
 
         if contentType != ["application/json"] {
-            throw Abort(.custom(code: 400, reasonPhrase: "Content-Type should be application/json"))
+            throw MemoError.contentTypeIsNotJSON
         }
 
         let patchMemo = try request.content.decode(PatchMemo.self)
 
         if let memoId = request.query[UUID.self, at: "memo-id"] {
             return Memo.find(memoId, on: request.db)
-                .unwrap(or: Abort(.notFound))
+                .unwrap(or: MemoError.notFound)
                 .flatMap { memo in
                     if let title = patchMemo.title { memo.title = title }
                     if let content = patchMemo.content { memo.content = content }
@@ -99,7 +99,7 @@ extension MemoController {
                     return memo.update(on: request.db).transform(to: .ok)
                 }
         } else {
-            throw Abort(.custom(code: 404, reasonPhrase: "memo-id not found"))
+            throw MemoError.wrongParameter
         }
     }
 }
@@ -115,7 +115,7 @@ extension MemoController {
                     return $0.delete(on: request.db)
                 }.transform(to: .ok)
         } else {
-            throw Abort(.custom(code: 404, reasonPhrase: "memo-id not found"))
+            throw MemoError.notFound
         }
     }
 }

--- a/Sources/App/Controllers/MemoController.swift
+++ b/Sources/App/Controllers/MemoController.swift
@@ -25,8 +25,8 @@ struct MemoController: RouteCollection {
 
 extension MemoController {
     private enum SortOrder: String, Decodable {
-        case ascending = "ascending"
-        case descending = "descending"
+        case ascending
+        case descending
     }
     
     private func getToDo(request: Request) throws -> EventLoopFuture<Page<Memo>> {

--- a/Sources/App/Controllers/MemoController.swift
+++ b/Sources/App/Controllers/MemoController.swift
@@ -72,12 +72,24 @@ struct MemoController: RouteCollection {
     }
     
     func create(request: Request) throws -> EventLoopFuture<Memo> {
+        let contentType = request.headers["Content-Type"]
+
+        if contentType != ["application/json"] {
+            throw Abort(.custom(code: 400, reasonPhrase: "Content-Type should be application/json"))
+        }
+
         try Memo.validate(content: request)
         let memo = try request.content.decode(Memo.self)
         return memo.create(on: request.db).map { memo }
     }
     
     func update(request: Request) throws -> EventLoopFuture<HTTPStatus> {
+        let contentType = request.headers["Content-Type"]
+
+        if contentType != ["application/json"] {
+            throw Abort(.custom(code: 400, reasonPhrase: "Content-Type should be application/json"))
+        }
+
         let patchMemo = try request.content.decode(PatchMemo.self)
 
         if let memoId = request.query[UUID.self, at: "memo-id"] {

--- a/Sources/App/MemoError.swift
+++ b/Sources/App/MemoError.swift
@@ -1,0 +1,36 @@
+//
+//  File.swift
+//  
+//
+//  Created by 천수현 on 2021/07/08.
+//
+
+import Vapor
+
+enum MemoError: AbortError {
+    case notFound
+    case contentTypeIsNotJSON
+    case wrongParameter
+    
+    var reason: String {
+        switch self {
+        case .notFound:
+            return "해당 Id를 가진 메모를 찾을수 없습니다."
+        case .contentTypeIsNotJSON:
+            return "Content-Type은 application/json이어야 합니다."
+        case .wrongParameter:
+            return "memo-id의 형식은 UUID여야 합니다."
+        }
+    }
+
+    var status: HTTPResponseStatus {
+        switch self {
+        case .notFound:
+            return .notFound
+        case .contentTypeIsNotJSON:
+            return .badRequest
+        case .wrongParameter:
+            return .badRequest
+        }
+    }
+}

--- a/Sources/App/Model/Memo.swift
+++ b/Sources/App/Model/Memo.swift
@@ -57,12 +57,3 @@ extension Memo: Validatable {
         validations.add("memo_type", as: String.self, is: .in("todo", "doing", "done"))
     }
 }
-
-/*
- {
-   "title": "String, example: 제목",
-   "content": "String, example: 내용",
-   "due_date": "Date, example: 2021-09-07T19:32:00Z",
-   "memo_type": "memo_type, exmaple: todo"
- }
- */

--- a/Sources/App/Model/Memo.swift
+++ b/Sources/App/Model/Memo.swift
@@ -48,3 +48,21 @@ extension Memo {
         case done
     }
 }
+
+extension Memo: Validatable {
+    static func validations(_ validations: inout Validations) {
+        validations.add("title", as: String.self, is: !.empty)
+        validations.add("content", as: String.self, is: !.empty)
+        validations.add("due_date", as: Date.self, is: .valid)
+        validations.add("memo_type", as: String.self, is: .in("todo", "doing", "done"))
+    }
+}
+
+/*
+ {
+   "title": "String, example: 제목",
+   "content": "String, example: 내용",
+   "due_date": "Date, example: 2021-09-07T19:32:00Z",
+   "memo_type": "memo_type, exmaple: todo"
+ }
+ */

--- a/Sources/App/Model/Memo.swift
+++ b/Sources/App/Model/Memo.swift
@@ -41,14 +41,6 @@ final class Memo: Model, Content {
     }
 }
 
-extension Memo {
-    enum MemoType: String, Codable {
-        case todo
-        case doing
-        case done
-    }
-}
-
 extension Memo: Validatable {
     static func validations(_ validations: inout Validations) {
         validations.add("title", as: String.self, is: !.empty)

--- a/Sources/App/Model/MemoType.swift
+++ b/Sources/App/Model/MemoType.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//  
+//
+//  Created by 천수현 on 2021/07/08.
+//
+
+import Foundation
+enum MemoType: String, Codable {
+    case todo
+    case doing
+    case done
+}

--- a/Sources/App/Model/PatchMemo.swift
+++ b/Sources/App/Model/PatchMemo.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  
+//
+//  Created by 천수현 on 2021/07/08.
+//
+
+import Vapor
+import Fluent
+
+struct PatchMemo: Decodable {
+    var title: String?
+    var content: String?
+    var due_date: Date?
+    var memo_type: MemoType?
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -3,24 +3,17 @@ import Fluent
 import FluentPostgresDriver
 
 public func configure(_ app: Application) throws {
-//    if let databaseURL = Environment.get("DATABASE_URL"), var postgresConfig = PostgresConfiguration(url: databaseURL) {
-//        var clientTLSConfiguration = TLSConfiguration.makeClientConfiguration()
-//        clientTLSConfiguration.certificateVerification = .none
-//        postgresConfig.tlsConfiguration = clientTLSConfiguration
-//
-//        app.databases.use(.postgres(
-//            configuration: postgresConfig
-//        ), as: .psql)
-//    } else {
-//        throw Abort(.custom(code: 500, reasonPhrase: "configuration failed"))
-//    }
+    if let databaseURL = Environment.get("DATABASE_URL"), var postgresConfig = PostgresConfiguration(url: databaseURL) {
+        var clientTLSConfiguration = TLSConfiguration.makeClientConfiguration()
+        clientTLSConfiguration.certificateVerification = .none
+        postgresConfig.tlsConfiguration = clientTLSConfiguration
 
-        app.databases.use(
-            .postgres(hostname: "localhost",
-                      username: "postgres",
-                      password: "",
-                      database: "memos"),
-            as: .psql)
+        app.databases.use(.postgres(
+            configuration: postgresConfig
+        ), as: .psql)
+    } else {
+        throw Abort(.custom(code: 500, reasonPhrase: "configuration failed"))
+    }
     app.migrations.add(MemoMigration())
     try routes(app)
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -3,18 +3,24 @@ import Fluent
 import FluentPostgresDriver
 
 public func configure(_ app: Application) throws {
-    if let databaseURL = Environment.get("DATABASE_URL"), var postgresConfig = PostgresConfiguration(url: databaseURL) {
-        var clientTLSConfiguration = TLSConfiguration.makeClientConfiguration()
-        clientTLSConfiguration.certificateVerification = .none
-        postgresConfig.tlsConfiguration = clientTLSConfiguration
+//    if let databaseURL = Environment.get("DATABASE_URL"), var postgresConfig = PostgresConfiguration(url: databaseURL) {
+//        var clientTLSConfiguration = TLSConfiguration.makeClientConfiguration()
+//        clientTLSConfiguration.certificateVerification = .none
+//        postgresConfig.tlsConfiguration = clientTLSConfiguration
+//
+//        app.databases.use(.postgres(
+//            configuration: postgresConfig
+//        ), as: .psql)
+//    } else {
+//        throw Abort(.custom(code: 500, reasonPhrase: "configuration failed"))
+//    }
 
-        app.databases.use(.postgres(
-            configuration: postgresConfig
-        ), as: .psql)
-    } else {
-        throw Abort(.custom(code: 500, reasonPhrase: "configuration failed"))
-    }
-
+        app.databases.use(
+            .postgres(hostname: "localhost",
+                      username: "postgres",
+                      password: "",
+                      database: "memos"),
+            as: .psql)
     app.migrations.add(MemoMigration())
     try routes(app)
 }

--- a/decodeTest/decodeTest/AppDelegate.swift
+++ b/decodeTest/decodeTest/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  decodeTest
+//
+//  Created by 천수현 on 2021/07/08.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/decodeTest/decodeTest/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/decodeTest/decodeTest/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/decodeTest/decodeTest/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/decodeTest/decodeTest/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/decodeTest/decodeTest/Assets.xcassets/Contents.json
+++ b/decodeTest/decodeTest/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/decodeTest/decodeTest/Base.lproj/LaunchScreen.storyboard
+++ b/decodeTest/decodeTest/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/decodeTest/decodeTest/Base.lproj/Main.storyboard
+++ b/decodeTest/decodeTest/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/decodeTest/decodeTest/Info.plist
+++ b/decodeTest/decodeTest/Info.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/decodeTest/decodeTest/SceneDelegate.swift
+++ b/decodeTest/decodeTest/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  decodeTest
+//
+//  Created by 천수현 on 2021/07/08.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/decodeTest/decodeTest/ViewController.swift
+++ b/decodeTest/decodeTest/ViewController.swift
@@ -1,0 +1,20 @@
+//
+//  ViewController.swift
+//  decodeTest
+//
+//  Created by 천수현 on 2021/07/08.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // Do any additional setup after loading the view.
+    }
+
+
+}
+


### PR DESCRIPTION
@delmaSong 
안녕하세요 델마! Step2에서 주신 피드백을 빠르게 반영해봤어요! 😆
Step3도 잘 부탁드립니다~

## 진행한 내용

### Validation

- Request header의 Content-Type이 application/json인지 검사하였습니다.
- request body가 지정한 type으로 decode될 수 있는지 검사하였습니다.
  (post의 경우 Memo type으로 decode될 수 있는지를 검사하였고, patch의 경우 PatchMemo를 통해 DTO방식의 구현을 사용하였습니다.)



### Pagination

- vapor내에 자체적으로 구현되어있는 page와 per라는 query parameter를 활용하여 pagination을 제작하였습니다.

- 별도로 코드를 작성할 필요는 없었고 클라이언트분들이 쉽게 이용하실 수 있도록 [API문서](https://app.swaggerhub.com/apis-docs/Neph3779/Project_Manager/1.0.0#/)를 수정했습니다.



### memo-id를 query parameter로 변경

단순히 path에 memo-id를 적는 것은 직관적이지 않고 type을 검사할수도 없었기에 query parameter로 변경하였습니다.



### 중복 코드 메서드화, 접근제어 지정자 설정

- 중복되는 코드를 메서드화하여 한결 더 간결하게 보일 수 있도록 했습니다.
- controller 파일은 MARK 주석으로 http메서드별로 구분하여 가독성을 높였습니다.



### MemoError 제작

- AbortError를 채택하는 MemoError를 제작하였습니다.
- 에러 메세지와 response로 전달될 http status code를 customize하였습니다.



## 고민한 부분

### key-value 쌍이 추가되어도 decoding 되는 JSON body

이번 프로젝트를 진행하던 중 json을 decode할 때, 요구하지 않은 key-value쌍이 json형식의 request body에 포함되어있어도 정상적으로 decoding이 되는것을 발견했습니다.

| ![img](https://raw.githubusercontent.com/Neph3779/Blog-Image/forUpload/img/20210709101933.png) |
| :----------------------------------------------------------: |
| 추가적인 key-value쌍을 제공했음에도 정상적으로 post작업이 이루어진 모습 |

이 문제에 대해서 오류메세지를 보내야한다는 의견과 그러지 않아도 괜찮다는 의견이 있었습니다.

델마는 어떻게 생각하시는지 궁금해요!



### Path Variable을 검사할 방법이 있을까요?

memo-id를 기존에는 path variable로 받을 예정이었습니다.

하지만 path variable로 받게되니 이를 검사할 방법을 찾을 수 없었기에 query parameter로 변경하게 되었습니다.

(위의 구현한 내용에도 적었듯 직관성 측면에서도 이게 더 나을 것 같았습니다.)

보통 path variable의 validation은 진행하지 않는 편인가요?


